### PR TITLE
Option to specify the desired molecular descriptor

### DIFF
--- a/sgdml/cli.py
+++ b/sgdml/cli.py
@@ -205,7 +205,8 @@ def _print_dataset_properties(dataset, title_str='Dataset properties'):
         + ui.white_bold_str('Example geometry')
         + ' (no. {:,}, chosen randomly)'.format(idx + 1)
     )
-    xyz_info_str = 'Copy&paste the string below into Jmol (www.jmol.org), Avogadro (www.avogadro.cc), etc. to visualize a geometry from this dataset. A new example will be drawn on each call.'
+    xyz_info_str = 'Copy&paste the string below into Jmol (www.jmol.org), Avogadro (www.avogadro.cc), etc. to ' \
+                   'visualize a geometry from this dataset. A new example will be drawn on each call.'
     xyz_info_str = ui.wrap_str(xyz_info_str, width=MAX_PRINT_WIDTH - 2)
     xyz_info_str = ui.indent_str(xyz_info_str, 2)
     print(xyz_info_str + '\n')
@@ -221,9 +222,8 @@ def _print_dataset_properties(dataset, title_str='Dataset properties'):
     print(xyz_str)
     print(cutline_str)
 
-
 def _print_task_properties(
-    use_sym, use_cprsn, use_E, use_E_cstr, title_str='Task properties'
+    use_sym, use_cprsn, use_E, use_E_cstr, descriptor, title_str='Task properties'
 ):
 
     print(ui.white_bold_str(title_str))
@@ -252,7 +252,11 @@ def _print_task_properties(
             'Compression:', 'requested' if use_cprsn else 'not requested'
         )
     )
-
+    print(
+        '  {:<16} {}'.format(
+            'Descriptor:', descriptor[0]
+        )
+    )
 
 def _print_model_properties(model, title_str='Model properties'):
 
@@ -270,6 +274,7 @@ def _print_model_properties(model, title_str='Model properties'):
     _, cprsn_keep_idxs = np.unique(
         np.sort(model['perms'], axis=0), axis=1, return_index=True
     )
+    print('  {:<18} {}'.format('Descriptor:', model['use_descriptor'][0]))
     n_atoms_kept = cprsn_keep_idxs.shape[0]
     print(
         '  {:<18} {}'.format(
@@ -349,6 +354,7 @@ def all(
     use_E,
     use_E_cstr,
     use_cprsn,
+    use_descriptor,
     overwrite,
     max_processes,
     use_torch,
@@ -398,6 +404,7 @@ def all(
         use_E,
         use_E_cstr,
         use_cprsn,
+        use_descriptor,
         overwrite,
         max_processes,
         task_dir,
@@ -424,6 +431,7 @@ def all(
         overwrite=False,
         max_processes=max_processes,
         use_torch=use_torch,
+        use_descriptor=use_descriptor,
         **kwargs
     )
 
@@ -443,6 +451,7 @@ def all(
         overwrite=False,
         max_processes=max_processes,
         use_torch=use_torch,
+        use_descriptor=use_descriptor,
         **kwargs
     )
 
@@ -466,6 +475,7 @@ def create(  # noqa: C901
     use_E,
     use_E_cstr,
     use_cprsn,
+    use_descriptor,
     overwrite,
     max_processes,
     task_dir=None,
@@ -487,7 +497,7 @@ def create(  # noqa: C901
         print()
 
     _print_task_properties(
-        use_sym=not gdml, use_cprsn=use_cprsn, use_E=use_E, use_E_cstr=use_E_cstr
+        use_sym=not gdml, use_cprsn=use_cprsn, use_E=use_E, use_E_cstr=use_E_cstr, descriptor=use_descriptor
     )
     print()
 
@@ -531,6 +541,7 @@ def create(  # noqa: C901
             use_cprsn=use_cprsn,
             use_E=use_E,
             use_E_cstr=use_E_cstr,
+            descriptor=use_descriptor[0],
             model0=model0,
         )
 
@@ -583,7 +594,8 @@ def create(  # noqa: C901
         if not use_E:
             log.info(
                 'Energy labels will be ignored for training.\n'
-                + 'Note: If available in the dataset file, the energy labels will however still be used to generate stratified training, test and validation datasets. Otherwise a random sampling is used.'
+                + 'Note: If available in the dataset file, the energy labels will however still be used to generate '
+                  'stratified training, test and validation datasets. Otherwise a random sampling is used.'
             )
 
         if 'E' not in dataset:
@@ -618,6 +630,7 @@ def create(  # noqa: C901
                 n_train,
                 valid_dataset,
                 n_valid,
+                use_descriptor,
                 sig=1,
                 use_sym=not gdml,
                 use_E=use_E,
@@ -808,7 +821,7 @@ def _online_err(err, size, n, mae_n_sum, rmse_n_sum):
 
 
 def validate(
-    model_dir, dataset, overwrite, max_processes, use_torch, command=None, **kwargs
+    model_dir, dataset, overwrite, max_processes, use_torch, use_descriptor, command=None, **kwargs
 ):
 
     dataset_path_extracted, dataset_extracted = dataset
@@ -827,6 +840,7 @@ def validate(
         overwrite,
         max_processes,
         use_torch,
+        use_descriptor,
         command,
         **kwargs
     )
@@ -859,6 +873,7 @@ def test(
     overwrite,
     max_processes,
     use_torch,
+    use_descriptor,
     command=None,
     **kwargs
 ):  # noqa: C901
@@ -1176,7 +1191,8 @@ def test(
                 else 'only {:,}'.format(len(test_idxs))
             )
             log.warning(
-                'This model has previously been tested on {:,} points, which is why the errors for the current test run with {} points have NOT been used to update the model file.\n'.format(
+                'This model has previously been tested on {:,} points, which is why the errors for the current test '
+                'run with {} points have NOT been used to update the model file.\n'.format(
                     model['n_test'], add_info_str
                 )
                 + 'Run \'{} test -o {} {} {}\' to overwrite.'.format(
@@ -1258,8 +1274,11 @@ def select(
 
         if any_model_is_tested:
             log.error(
-                'One or more models in the given directory have already been tested. This means that their recorded expected errors are test errors, not validation errors. However, one should never perform model selection based on the test error!\n'
-                + 'Please run the validation command (again) with the overwrite option \'-o\', then this selection command.'
+                'One or more models in the given directory have already been tested. This means that their recorded '
+                'expected errors are test errors, not validation errors. However, one should never perform model '
+                'selection based on the test error!\n'
+                + 'Please run the validation command (again) with the overwrite option \'-o\', '
+                  'then this selection command.'
             )
             return
 
@@ -1439,6 +1458,18 @@ def main():
         action='store_true',
         help='use PyTorch for validation and test (including kernel evaluations in some numerical solvers)',
     )
+    # TODO: Add more descriptors
+    parent_parser.add_argument(
+        '-descr',
+        '--descriptor',
+        metavar='<descriptor [args...]>',
+        dest='use_descriptor',
+        type=io.parse_descriptor,
+        help='sets the descriptor to be used and their required arguments (e.g. -descr coulomb_matrix/exp_decay_matrix).',
+        # choices=['coulomb_matrix', 'exp_decay_matrix'],
+        default=['coulomb_matrix'],
+        nargs='+',
+    )
 
     subparsers = parser.add_subparsers(title='commands', dest='command')
     subparsers.required = True
@@ -1472,7 +1503,8 @@ def main():
     for subparser in [parser_all, parser_create]:
         _add_argument_dataset(
             subparser,
-            help='path to dataset file (train/validation/test subsets are sampled from here if no seperate dataset are specified)',
+            help='path to dataset file (train/validation/test subsets are sampled '
+                 'from here if no separated dataset are specified)',
         )
         _add_argument_sample_size(subparser, 'train')
         _add_argument_sample_size(subparser, 'valid')
@@ -1512,7 +1544,7 @@ def main():
         group.add_argument(
             '--gdml',
             action='store_true',
-            help='don\'t include symmetries in the model (GDML)',
+            help='do not include symmetries in the model (GDML)',
         )
         group.add_argument(
             '--cprsn',
@@ -1563,15 +1595,17 @@ def main():
             '--cg',
             dest='use_cg',
             action='store_true',
-            # help='use iterative solver (conjugate gradient) with Nystroem preconditioner',
-            help=argparse.SUPPRESS
+            help='',
+            #help=argparse.SUPPRESS,
+            #help='use iterative solver (conjugate gradient) with Nystroem preconditioner',
         )
         subparser.add_argument(
             '-m0',
             '--model0',
             metavar='<initial_model_file>',
             type=lambda x: io.is_file_type(x, 'model'),
-            help='initial model file used as a source for training task parameters, including training and validation subsets, permutations, initial set of coefficients (for numerical solvers)',
+            help='initial model file used as a source for training task parameters, including training and validation '
+                 'subsets, permutations, initial set of coefficients (for numerical solvers)',
             nargs='?',
             default=None,
         )
@@ -1601,6 +1635,16 @@ def main():
         if not args.model_file.endswith('.npz'):
             args.model_file += '.npz'
 
+    # post-processing of descriptor flag
+    # Looks for dependencies in case that an external descriptor is provided
+    if 'use_descriptor' in args:
+
+        if args.use_descriptor[0] == 'coulomb_matrix':
+            pass
+
+        if args.use_descriptor[0] == 'exp_decay_matrix':
+            pass
+
     _print_splash(args.max_processes)
 
     # Check PyTorch GPU support.
@@ -1609,12 +1653,15 @@ def main():
             if not torch.cuda.is_available():
                 print()  # TODO: print only if log level includes warning
                 log.warning(
-                    'Your PyTorch installation does not see any GPU(s) on your system and will thus run all calculations on the CPU! Unless this is what you want, we recommend running CPU calculations without \'--torch\' for improved performance.'
+                    'Your PyTorch installation does not see any GPU(s) on your system and will thus run all '
+                    'calculations on the CPU! Unless this is what you want, we recommend running CPU calculations '
+                    'without \'--torch\' for improved performance.'
                 )
         else:
             print()
             log.critical(
-                'Optional PyTorch dependency not found! Please run \'pip install sgdml[torch]\' to install it or disable the PyTorch option.'
+                'Optional PyTorch dependency not found! Please run \'pip install sgdml[torch]\' to install it or '
+                'disable the PyTorch option.'
             )
             sys.exit()
 

--- a/sgdml/predict.py
+++ b/sgdml/predict.py
@@ -279,7 +279,12 @@ class GDMLPredict(object):
 
         self.n_atoms = model['z'].shape[0]
 
-        self.desc = Desc(self.n_atoms, max_processes=max_processes)
+        self.use_descriptor = model['use_descriptor']
+
+        #elif self.use_descriptor[0] == 'non_default_descr':
+        #    pass
+
+        self.desc = Desc(self.n_atoms, max_processes=max_processes, use_descriptor=self.use_descriptor[0])
         glob['desc_func'] = self.desc
 
         self.lat_and_inv = (

--- a/sgdml/predict.py
+++ b/sgdml/predict.py
@@ -215,7 +215,7 @@ def _predict_wkr(
         out = np.empty((dim_i + 1,))
         out[0] = E_F[0]
 
-    np.dot(F, r_d_desc, out=out[1:])
+    out[1:] = np.dot(F, r_d_desc)
 
     return out
 

--- a/sgdml/torchtools.py
+++ b/sgdml/torchtools.py
@@ -2,7 +2,7 @@
 
 # MIT License
 #
-# Copyright (c) 2019-2020 Jan Hermann, Stefan Chmiela
+# Copyright (c) 2019 Jan Hermann
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,14 +22,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import logging
 import numpy as np
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
-#from psutil import virtual_memory
 
-from .utils.desc import Desc
+from .utils import desc
 
 
 def expand_tril(xs):
@@ -49,141 +47,70 @@ class GDMLTorchPredict(nn.Module):
     :class:`torch.nn.Module`. Contains no trainable parameters.
     """
 
-    def __init__(self, model, lat_and_inv=None, batch_size=None, max_memory=None):
+    def __init__(self, model, lat_and_inv=None, batch_size=None, max_memory=1.0):
         """
         Parameters
         ----------
         model : Mapping
             Obtained from :meth:`~train.GDMLTrain.train`.
-        lat_and_inv : tuple of :obj:`numpy.ndarray`
-            Tuple of 3 x 3 matrix containing lattice vectors as columns and its inverse.
         batch_size : int, optional
             Maximum batch size of geometries for prediction. Calculated from
             :paramref:`max_memory` if not given.
+        lat_and_inv : tuple of :obj:`numpy.ndarray`
+            Tuple of 3 x 3 matrix containing lattice vectors as columns and its inverse.
         max_memory : float, optional
             (unit GB) Maximum allocated memory for prediction.
         """
 
-        global _batch_size
-
         super(GDMLTorchPredict, self).__init__()
 
-        self._log = logging.getLogger(__name__)
+        model = dict(model)  # hack
 
-        model = dict(model)
-
-        self._dev = 'cuda' if torch.cuda.is_available() else 'cpu'
+        torch_device = 'cuda' if torch.cuda.is_available() else 'cpu'
         self._lat_and_inv = (
             None
             if lat_and_inv is None
             else (
-                torch.tensor(lat_and_inv[0], device=self._dev),
-                torch.tensor(lat_and_inv[1], device=self._dev),
+                torch.tensor(lat_and_inv[0], device=torch_device),
+                torch.tensor(lat_and_inv[1], device=torch_device),
             )
         )
 
+        self._batch_size = batch_size
+        self._max_memory = int(2 ** 30 * max_memory)
         self._sig = int(model['sig'])
         self._c = float(model['c'])
         self._std = float(model.get('std', 1))
+        self.use_descriptor = model['use_descriptor']
 
         desc_siz = model['R_desc'].shape[0]
         n_perms, self._n_atoms = model['perms'].shape
-        perm_idxs = (
-            torch.tensor(model['tril_perms_lin'], device=self._dev)
-            .view(-1, n_perms)
-            .t()
-        )
+        perm_idxs = torch.tensor(model['tril_perms_lin']).view(-1, n_perms).t()
         self._xs_train, self._Jx_alphas = (
             nn.Parameter(
                 xs.repeat(1, n_perms)[:, perm_idxs].reshape(-1, desc_siz),
                 requires_grad=False,
             )
             for xs in (
-                torch.tensor(model['R_desc'], device=self._dev).t(),
-                torch.tensor(np.array(model['R_d_desc_alpha']), device=self._dev),
+                torch.tensor(model['R_desc']).t(),
+                torch.tensor(np.array(model['R_d_desc_alpha'])),
             )
-        )
-
-        if max_memory is not None:
-            _max_memory = int(2 ** 30 * max_memory)  # GB to bytes
-        else:
-            if torch.cuda.is_available():
-                _max_memory = max(
-                    [
-                        torch.cuda.get_device_properties(i).total_memory
-                        for i in range(torch.cuda.device_count())
-                    ]
-                )
-            else:
-                #_max_memory = virtual_memory().total
-                _max_memory = int(2 ** 30 * 32) # 32 GB TODO: hardcoded for now, to avoid psutils
-
-        _batch_size = (
-            _max_memory // self._memory_per_sample()
-            if batch_size is None
-            else batch_size
-        )
-        if torch.cuda.is_available():
-            _batch_size *= torch.cuda.device_count()
-
-        self.desc_siz = desc_siz
-        self.perm_idxs = perm_idxs
-        self.n_perms = n_perms
-
-        #self.desc = Desc(self._n_atoms)
-
-    def set_alphas(self, R_d_desc, alphas):
-        """
-        Reconfigure the current model with a new set of regression parameters.
-        This is necessary when training the model iteratively.
-
-        Parameters
-        ----------
-                R_d_desc : :obj:`numpy.ndarray`
-                    Array containing the Jacobian of the descriptor for
-                    each training point.
-                alphas : :obj:`numpy.ndarray`
-                    1D array containing the new model parameters.
-        """
-
-        r_dim = R_d_desc.shape[2]
-        R_d_desc_alpha = np.einsum('kji,ki->kj', R_d_desc, alphas.reshape(-1, r_dim))
-
-        xs = torch.tensor(np.array(R_d_desc_alpha), device=self._dev)
-        self._Jx_alphas = nn.Parameter(
-            xs.repeat(1, self.n_perms)[:, self.perm_idxs].reshape(-1, self.desc_siz),
-            requires_grad=False,
         )
 
     def _memory_per_sample(self):
         return 3 * self._xs_train.nelement() * self._xs_train.element_size()
-
-    def _batch_size(self):
-        return _batch_size
 
     def _forward(self, Rs):
         sig = self._sig
         q = np.sqrt(5) / sig
 
         diffs = Rs[:, :, None, :] - Rs[:, None, :, :]
+
         if self._lat_and_inv is not None:
             diffs_shape = diffs.shape
-            #diffs = self.desc.pbc_diff(diffs.reshape(-1, 3), self._lat_and_inv).reshape(
-            #    diffs_shape
-            #)
-
-            lat, lat_inv = self._lat_and_inv
-
-            if lat.device != Rs.device:
-                lat=lat.to(Rs.device)
-                lat_inv=lat_inv.to(Rs.device)
-            
-            diffs = diffs.reshape(-1, 3)
-
-            c = lat_inv.mm(diffs.t())
-            diffs -= lat.mm(c.round()).t()
-
-            diffs = diffs.reshape(diffs_shape)
+            diffs = desc.pbc_diff_torch(
+                diffs.reshape(-1, 3), self._lat_and_inv
+            ).reshape(diffs_shape)
 
         dists = diffs.norm(dim=-1)
         i, j = np.diag_indices(self._n_atoms)
@@ -191,7 +118,10 @@ class GDMLTorchPredict(nn.Module):
         dists[:, i, j] = np.inf
         i, j = np.tril_indices(self._n_atoms, k=-1)
 
-        xs = 1 / dists[:, i, j]  # R_desc (1000, 36)
+        if self.use_descriptor[0] == 'coulomb_matrix':
+            xs = 1 / dists[:, i, j]
+        elif self.use_descriptor[0] == 'exp_decay_matrix':
+            xs = torch.exp(-dists[:, i, j])
 
         x_diffs = (q * xs)[:, None, :] - q * self._xs_train
         x_dists = x_diffs.norm(dim=-1)
@@ -202,22 +132,20 @@ class GDMLTorchPredict(nn.Module):
         F2s_x = exp_xs_1_x_dists.mm(self._Jx_alphas)
         Fs_x = (F1s_x - F2s_x) * self._std
 
-        Fs = ((expand_tril(Fs_x) / dists ** 3)[..., None] * diffs).sum(
-            dim=1
-        )  # * R_d_desc
+        Fs = ((expand_tril(Fs_x) / dists ** 3)[..., None] * diffs).sum(dim=1)
 
         Es = (exp_xs_1_x_dists * dot_x_diff_Jx_alphas).sum(dim=-1) / q
         Es = self._c + Es * self._std
 
         return Es, Fs
 
-    def forward(self, Rs):
+    def forward(self, Rs, batch_size=None, max_memory=None):
         """
         Predict energy and forces for a batch of geometries.
 
         Parameters
         ----------
-        Rs : :obj:`torch.Tensor`
+        R : :obj:`torch.Tensor`
             (dims M x N x 3) Cartesian coordinates of M molecules composed of N atoms
 
         Returns
@@ -228,44 +156,13 @@ class GDMLTorchPredict(nn.Module):
             (dims M x N x 3) Nuclear gradients of the energy
         """
 
-        global _batch_size
-
         assert Rs.dim() == 3
         assert Rs.shape[1:] == (self._n_atoms, 3)
 
         dtype = Rs.dtype
         Rs = Rs.double()
+        batch_size = self._batch_size or self._max_memory // self._memory_per_sample()
 
-        batch_size = _batch_size
-
-        retry = True
-        while retry:
-
-            try:
-                Es, Fs = zip(*map(self._forward, DataLoader(Rs, batch_size=batch_size)))
-                retry = False
-
-            except RuntimeError as e:
-                if 'out of memory' in str(e):
-                    if batch_size > 2:
-
-                        import gc
-                        gc.collect()
-
-                        torch.cuda.empty_cache()
-
-                        batch_size -= 1
-                        _batch_size = batch_size
-
-                        retry = True
-
-                    else:
-                        self._log.critical(
-                            'Could not allocate enough memory to evaluate model, despite reducing batch size.'
-                        )
-                        print()
-                        sys.exit()
-                else:
-                    raise e
+        Es, Fs = zip(*map(self._forward, DataLoader(Rs, batch_size=batch_size)))
 
         return torch.cat(Es).to(dtype), torch.cat(Fs).to(dtype)

--- a/sgdml/utils/io.py
+++ b/sgdml/utils/io.py
@@ -160,7 +160,7 @@ def z_to_z_str(z):
 
 
 def train_dir_name(
-    dataset, n_train, use_sym, use_cprsn, use_E, use_E_cstr, model0=None
+    dataset, n_train, use_sym, use_cprsn, use_E, use_E_cstr, descriptor, model0=None
 ):
 
     theory_level_str = re.sub(r'[^\w\-_\.]', '.', str(dataset['theory']))
@@ -172,10 +172,11 @@ def train_dir_name(
     noE_str = '-noE' if not use_E else ''
     Ecstr_str = '-Ecstr' if use_E_cstr else ''
 
-    return '%ssgdml_cv_%s-%s-train%d%s%s%s%s' % (
+    return '%ssgdml_cv_%s-%s-%s-train%d%s%s%s%s' % (
         m0_str,
         dataset['name'].astype(str),
         theory_level_str,
+        descriptor,
         n_train,
         sym_str,
         cprsn_str,
@@ -190,7 +191,7 @@ def task_file_name(task):
     n_perms = task['perms'].shape[0]
     sig = np.squeeze(task['sig'])
 
-    return 'task-train%d-sym%d-sig%04d.npz' % (n_train, n_perms, sig)
+    return 'task-%s-train%d-sym%d-sig%04d.npz' % (task['use_descriptor'][0], n_train, n_perms, sig)
 
 
 def model_file_name(task_or_model, is_extended=False):
@@ -205,8 +206,8 @@ def model_file_name(task_or_model, is_extended=False):
             r'[^\w\-_\.]', '.', str(np.squeeze(task_or_model['dataset_theory']))
         )
         theory_level_str = re.sub(r'\.\.', '.', theory_level_str)
-        return '%s-%s-train%d-sym%d.npz' % (dataset, theory_level_str, n_train, n_perms)
-    return 'model-train%d-sym%d-sig%04d.npz' % (n_train, n_perms, sig)
+        return '%s-%s-%s-train%d-sym%d.npz' % (dataset, theory_level_str, task_or_model['use_descriptor'][0], n_train, n_perms)
+    return 'model-%s-train%d-sym%d-sig%04d.npz' % (task_or_model['use_descriptor'][0], n_train, n_perms, sig)
 
 
 def dataset_md5(dataset):
@@ -705,3 +706,24 @@ def parse_list_or_range(arg):
             arg
         )
     )
+
+def parse_descriptor(arg):
+    """
+    Parses a string that represents either just descriptor's name or required arguments too.
+
+    Parameters
+    ----------
+        arg : :obj:`str`
+            string.
+
+    Returns
+    -------
+        str or :obj:`list` of str
+
+    Raises
+    ------
+        ArgumentTypeError
+            If input can neither be interpreted as a str or list of str.
+    """
+
+    return arg


### PR DESCRIPTION
The option to specify the desired molecular descriptor is added to the sGDML software under the flag -descr/--descriptor. 
The default option is still the Coulomb matrix. The new option is the exponential decay matrix D_ij=exp(-r_ij), which is accessible via the "-descr exp_decay_matrix".
Adding new descriptors is a straight forward task by following the exponential decay matrix example.