### PR TITLE
The option to specify the desired molecular descriptor

### DIFF
--- a/sgdml/predict.py
+++ b/sgdml/predict.py
@@ -280,7 +280,12 @@ class GDMLPredict(object):
 
         self.n_atoms = model['z'].shape[0]
 
-        self.desc = Desc(self.n_atoms, max_processes=max_processes)
+        self.use_descriptor = model['use_descriptor']
+
+        # elif self.use_descriptor[0] == 'non_default_descr':
+        #    pass
+
+        self.desc = Desc(self.n_atoms, max_processes=max_processes, use_descriptor=self.use_descriptor[0])
         glob['desc_func'] = self.desc
 
         self.lat_and_inv = (

--- a/sgdml/train.py
+++ b/sgdml/train.py
@@ -261,7 +261,8 @@ class GDMLTrain(object):
 
         if use_torch and not _has_torch:
             raise ImportError(
-                'Optional PyTorch dependency not found! Please run \'pip install sgdml[torch]\' to install it or disable the PyTorch option.'
+                'Optional PyTorch dependency not found! Please run \'pip install sgdml[torch]\' to install it or '
+                'disable the PyTorch option.'
             )
 
     def __del__(self):
@@ -275,6 +276,7 @@ class GDMLTrain(object):
         n_train,
         valid_dataset,
         n_valid,
+        use_descriptor,
         sig,
         lam=1e-15,
         use_sym=True,
@@ -311,6 +313,8 @@ class GDMLTrain(object):
                 validation dataset.
             n_valid : int
                 Number of validation points to sample.
+            use_descriptor : list
+                List containing the name of the descriptor to use.
             sig : int
                 Hyper-parameter (kernel length scale).
             lam : float, optional
@@ -453,6 +457,7 @@ class GDMLTrain(object):
             'use_E_cstr': use_E_cstr,
             'use_sym': use_sym,
             'use_cprsn': use_cprsn,
+            'use_descriptor': use_descriptor,
             'solver_name': solver,
             'solver_tol': solver_tol,
         }
@@ -470,7 +475,8 @@ class GDMLTrain(object):
                 lat_and_inv = (task['lattice'], np.linalg.inv(task['lattice']))
             except np.linalg.LinAlgError:
                 raise ValueError(  # TODO: Document me
-                    'Provided dataset contains invalid lattice vectors (not invertible). Note: Only rank 3 lattice vector matrices are supported.'
+                    'Provided dataset contains invalid lattice vectors (not invertible). Note: Only rank 3 lattice '
+                    'vector matrices are supported.'
                 )
 
         if 'r_unit' in train_dataset and 'e_unit' in train_dataset:
@@ -486,7 +492,8 @@ class GDMLTrain(object):
                         np.random.choice(n_train, 1000, replace=False), :, :
                     ]
                     self.log.info(
-                        'Symmetry search has been restricted to a random subset of 1000/{:d} training points for faster convergence.'.format(
+                        'Symmetry search has been restricted to a random subset of 1000/{:d} training points for '
+                        'faster convergence.'.format(
                             n_train
                         )
                     )
@@ -701,6 +708,7 @@ class GDMLTrain(object):
             'tril_perms_lin': tril_perms_lin,
             'use_E': task['use_E'],
             'use_cprsn': task['use_cprsn'],
+            'use_descriptor': task['use_descriptor'],
         }
 
         if solver_resid is not None:
@@ -802,15 +810,25 @@ class GDMLTrain(object):
 
         n_train, n_atoms = task['R_train'].shape[:2]
 
+        use_descriptor = task['use_descriptor']
+
         desc = Desc(
-            n_atoms, max_processes=self._max_processes
+            n_atoms, max_processes=self._max_processes, use_descriptor=use_descriptor[0]
         )
 
         sig = np.squeeze(task['sig'])
         lam = np.squeeze(task['lam'])
 
         n_perms = task['perms'].shape[0]
-        tril_perms = np.array([desc.perm(p) for p in task['perms']])
+
+        if use_descriptor[0] == 'coulomb_matrix' or use_descriptor[0] == 'exp_decay_matrix':
+            tril_perms = np.array([desc.perm(p) for p in task['perms']])
+            descriptor_type = {
+                'use_descriptor': use_descriptor[0]
+            }
+
+        # elif 'other_descriptor' == use_descriptor[0]:
+        #    pass
 
         dim_i = 3 * n_atoms
         dim_d = desc.dim
@@ -826,7 +844,8 @@ class GDMLTrain(object):
                 lat_and_inv = (task['lattice'], np.linalg.inv(task['lattice']))
             except np.linalg.LinAlgError:
                 raise ValueError(  # TODO: Document me
-                    'Provided dataset contains invalid lattice vectors (not invertible). Note: Only rank 3 lattice vector matrices are supported.'
+                    'Provided dataset contains invalid lattice vectors (not invertible). Note: Only rank 3 lattice '
+                    'vector matrices are supported.'
                 )
 
             # # TODO: check if all atoms are within unit cell
@@ -1085,14 +1104,17 @@ class GDMLTrain(object):
             self.log.warning(
                 'The provided dataset contains gradients instead of force labels (flipped sign). Please correct!\n'
                 + ui.color_str('Note:', bold=True)
-                + 'Note: The energy prediction accuracy of the model will thus neither be validated nor tested in the following steps!'
+                + 'Note: The energy prediction accuracy of the model will thus neither be validated nor tested in the '
+                  'following steps!'
             )
             return None
 
         if corrcoef < 0.95:
             self.log.warning(
                 'Inconsistent energy labels detected!\n'
-                + 'The predicted energies for the training data are only weakly correlated with the reference labels (correlation coefficient {:.2f}) which indicates that the issue is most likely NOT just a unit conversion error.\n\n'.format(
+                + 'The predicted energies for the training data are only weakly correlated with the reference labels '
+                  '(correlation coefficient {:.2f}) which indicates that the issue is most likely NOT just a unit '
+                  'conversion error.\n\n'.format(
                     corrcoef
                 )
                 + ui.color_str('Troubleshooting tips:\n', bold=True)
@@ -1132,7 +1154,8 @@ class GDMLTrain(object):
         if np.abs(e_fact - 1) > 1e-1:
             self.log.warning(
                 'Different scales in energy vs. force labels detected!\n'
-                + 'The integrated forces differ from the energy labels by factor ~{:.2f}, meaning that the trained model will likely fail to predict energies accurately.\n\n'.format(
+                + 'The integrated forces differ from the energy labels by factor ~{:.2f}, meaning that the trained '
+                  'model will likely fail to predict energies accurately.\n\n'.format(
                     e_fact
                 )
                 + ui.color_str('Troubleshooting tips:\n', bold=True)

--- a/sgdml/utils/desc.py
+++ b/sgdml/utils/desc.py
@@ -46,7 +46,7 @@ def _from_r_alias(obj, r, lat_and_inv=None):
 
 
 class Desc(object):
-    def __init__(self, n_atoms, max_processes=None):
+    def __init__(self, n_atoms, max_processes=None, use_descriptor='coulomb_matrix'):
         """
         Generate descriptors and their Jacobians for molecular geometries,
         including support for periodic boundary conditions.
@@ -64,28 +64,36 @@ class Desc(object):
         self.n_atoms = n_atoms
         self.dim_i = 3 * n_atoms
 
+        self.use_descriptor = use_descriptor
+
         # Size of the resulting descriptor vector.
-        self.dim = (n_atoms * (n_atoms - 1)) // 2
+        if self.use_descriptor == 'coulomb_matrix' or self.use_descriptor == 'exp_decay_matrix':
+            # Size of the resulting descriptor vector.
+            self.dim = (n_atoms * (n_atoms - 1)) // 2
 
-        # Precompute indices for nonzero entries in desriptor derivatives.
-        self.d_desc_mask = np.zeros((n_atoms, n_atoms - 1), dtype=np.int)
-        for a in range(n_atoms):  # for each partial derivative
-            rows, cols = np.tril_indices(n_atoms, -1)
-            self.d_desc_mask[a, :] = np.concatenate(
-                [np.where(rows == a)[0], np.where(cols == a)[0]]
-            )
+            # Precompute indices for nonzero entries in desriptor derivatives.
+            self.d_desc_mask = np.zeros((n_atoms, n_atoms - 1), dtype=np.int)
+            for a in range(n_atoms):  # for each partial derivative
+                rows, cols = np.tril_indices(n_atoms, -1)
+                self.d_desc_mask[a, :] = np.concatenate(
+                    [np.where(rows == a)[0], np.where(cols == a)[0]]
+                )
 
-        self.M = np.arange(1, n_atoms)  # indexes matrix row-wise, skipping diagonal
-        for a in range(1, n_atoms):
-            self.M = np.concatenate((self.M, np.delete(np.arange(n_atoms), a)))
+            self.M = np.arange(1, n_atoms)  # indexes matrix row-wise, skipping diagonal
+            for a in range(1, n_atoms):
+                self.M = np.concatenate((self.M, np.delete(np.arange(n_atoms), a)))
 
-        self.A = np.repeat(
-            np.arange(n_atoms), n_atoms - 1
-        )  # [0, 0, ..., 1, 1, ..., 2, 2, ...]
+            self.A = np.repeat(
+                np.arange(n_atoms), n_atoms - 1
+            )  # [0, 0, ..., 1, 1, ..., 2, 2, ...]
 
-        self.d_desc = np.zeros(
-            (self.dim, n_atoms, 3)
-        )  # template for descriptor matrix (zeros are important)
+            self.d_desc = np.zeros(
+                (self.dim, n_atoms, 3)
+            )  # template for descriptor matrix (zeros are important)
+
+        # --- TODO: Add precomputable variables for new descriptor here
+        # elif self.use_descriptor == '':
+        #    pass
 
         self.max_processes = max_processes
 
@@ -250,8 +258,16 @@ class Desc(object):
 
         pd = self._pdist(r, lat_and_inv)
 
-        r_desc = self._r_to_desc(r, pd)
-        r_d_desc = self._r_to_d_desc(r, pd, lat_and_inv)
+        if self.use_descriptor == 'coulomb_matrix':
+            pd = self._pdist(r, lat_and_inv)
+
+            r_desc = self._r_to_desc(r, pd)
+            r_d_desc = self._r_to_d_desc(r, pd, lat_and_inv)
+
+        elif self.use_descriptor == 'exp_decay_matrix':
+            pd = self._pdist(r, lat_and_inv)
+            r_desc = self._r_to_desc_exp_decay(r, pd)
+            r_d_desc = self._r_to_d_desc_exp_decay(r, pd, lat_and_inv)
 
         return r_desc, r_d_desc
 
@@ -284,6 +300,7 @@ class Desc(object):
 
         return sp.spatial.distance.squareform(pdist, checks=False)
 
+    # --- Coulomb Matrix descriptor
     def _r_to_desc(self, r, pdist):
         """
         Generate descriptor for a set of atom positions in Cartesian
@@ -347,6 +364,72 @@ class Desc(object):
             ).reshape(self.n_atoms, self.n_atoms, 3)
 
         d_desc_elem = pdiff / (pdist ** 3)[:, :, None]
+        self.d_desc[self.d_desc_mask.ravel(), self.A, :] = d_desc_elem[
+            self.M, self.A, :
+        ]
+
+        return self.d_desc.reshape(self.dim, self.dim_i)
+
+    # --- Exponential decay matrix
+    def _r_to_desc_exp_decay(self, r, pdist):
+        """
+        Generate descriptor for a set of atom positions in Cartesian
+        coordinates.
+        Parameters
+        ----------
+            r : :obj:`numpy.ndarray`
+                Array of size 3N containing the Cartesian coordinates of
+                each atom.
+            pdist : :obj:`numpy.ndarray`
+                Array of size N x N containing the Euclidean distance
+                (2-norm) for each pair of atoms.
+        Returns
+        -------
+            :obj:`numpy.ndarray`
+                Descriptor representation as 1D array of size N(N-1)/2
+        """
+
+        # Add singleton dimension if input is (,3N).
+        if r.ndim == 1:
+            r = r[None, :]
+
+        return np.exp(-pdist[np.tril_indices(self.n_atoms, -1)])
+
+    def _r_to_d_desc_exp_decay(self, r, pdist, lat_and_inv=None):
+        """
+        Generate descriptor Jacobian for a set of atom positions in
+        Cartesian coordinates.
+        This method can apply the minimum-image convention as periodic
+        boundary condition for distances between atoms, given the edge
+        length of the (square) unit cell.
+        Parameters
+        ----------
+            r : :obj:`numpy.ndarray`
+                Array of size 3N containing the Cartesian coordinates of
+                each atom.
+            pdist : :obj:`numpy.ndarray`
+                Array of size N x N containing the Euclidean distance
+                (2-norm) for each pair of atoms.
+            lat_and_inv : tuple of :obj:`numpy.ndarray`, optional
+                Tuple of 3x3 matrix containing lattice vectors as columns and its inverse.
+        Returns
+        -------
+            :obj:`numpy.ndarray`
+                Array of size N(N-1)/2 x 3N containing all partial
+                derivatives of the descriptor.
+        """
+
+        r = r.reshape(-1, 3)
+
+        np.seterr(divide='ignore', invalid='ignore')
+
+        pdiff = r[:, None] - r[None, :]  # pairwise differences ri - rj
+        if lat_and_inv is not None:
+            pdiff = self.pbc_diff(
+                pdiff.reshape(self.n_atoms ** 2, 3), lat_and_inv
+            ).reshape(self.n_atoms, self.n_atoms, 3)
+
+        d_desc_elem = np.exp(-pdist[:, :, None]) * pdiff / pdist[:, :, None]
         self.d_desc[self.d_desc_mask.ravel(), self.A, :] = d_desc_elem[
             self.M, self.A, :
         ]

--- a/sgdml/utils/io.py
+++ b/sgdml/utils/io.py
@@ -160,7 +160,7 @@ def z_to_z_str(z):
 
 
 def train_dir_name(
-    dataset, n_train, use_sym, use_cprsn, use_E, use_E_cstr, model0=None
+    dataset, n_train, use_sym, use_cprsn, use_E, use_E_cstr, descriptor, model0=None
 ):
 
     theory_level_str = re.sub(r'[^\w\-_\.]', '.', str(dataset['theory']))
@@ -172,10 +172,11 @@ def train_dir_name(
     noE_str = '-noE' if not use_E else ''
     Ecstr_str = '-Ecstr' if use_E_cstr else ''
 
-    return '%ssgdml_cv_%s-%s-train%d%s%s%s%s' % (
+    return '%ssgdml_cv_%s-%s-%s-train%d%s%s%s%s' % (
         m0_str,
         dataset['name'].astype(str),
         theory_level_str,
+        descriptor,
         n_train,
         sym_str,
         cprsn_str,
@@ -190,7 +191,7 @@ def task_file_name(task):
     n_perms = task['perms'].shape[0]
     sig = np.squeeze(task['sig'])
 
-    return 'task-train%d-sym%d-sig%04d.npz' % (n_train, n_perms, sig)
+    return 'task-%s-train%d-sym%d-sig%04d.npz' % (task['use_descriptor'][0], n_train, n_perms, sig)
 
 
 def model_file_name(task_or_model, is_extended=False):
@@ -205,8 +206,8 @@ def model_file_name(task_or_model, is_extended=False):
             r'[^\w\-_\.]', '.', str(np.squeeze(task_or_model['dataset_theory']))
         )
         theory_level_str = re.sub(r'\.\.', '.', theory_level_str)
-        return '%s-%s-train%d-sym%d.npz' % (dataset, theory_level_str, n_train, n_perms)
-    return 'model-train%d-sym%d-sig%04d.npz' % (n_train, n_perms, sig)
+        return '%s-%s-%s-train%d-sym%d.npz' % (dataset, theory_level_str, task_or_model['use_descriptor'][0], n_train, n_perms)
+    return 'model-%s-train%d-sym%d-sig%04d.npz' % (task_or_model['use_descriptor'][0], n_train, n_perms, sig)
 
 
 def dataset_md5(dataset):
@@ -705,3 +706,21 @@ def parse_list_or_range(arg):
             arg
         )
     )
+
+def parse_descriptor(arg):
+    """
+    Parses a string that represents either just descriptor's name or required arguments too.
+    Parameters
+    ----------
+        arg : :obj:`str`
+            string.
+    Returns
+    -------
+        str or :obj:`list` of str
+    Raises
+    ------
+        ArgumentTypeError
+            If input can neither be interpreted as a str or list of str.
+    """
+
+    return arg


### PR DESCRIPTION
The option to specify the desired molecular descriptor is added to the sGDML software under the flag -descr/--descriptor.

The default option is still the Coulomb matrix. The new option is the exponential decay matrix D_ij=exp(-r_ij), which is accessible via the "-descr exp_decay_matrix".
Adding new descriptors is a straight forward task by following the exponential decay matrix example.