### PR TITLE
bug fix for "_bmark_cache.npz file stores at program path"

### DIFF
--- a/sgdml/cli.py
+++ b/sgdml/cli.py
@@ -1613,9 +1613,9 @@ def reset(command=None, **kwargs):
 
     if ui.yes_or_no('\nDo you really want to purge all caches and temporary files?'):
 
-        pkg_dir = os.path.dirname(os.path.abspath(__file__))
+        curr_dir = os.getcwd()
         bmark_file = '_bmark_cache.npz'
-        bmark_path = os.path.join(pkg_dir, bmark_file)
+        bmark_path = os.path.join(curr_dir, bmark_file)
 
         if os.path.exists(bmark_path):
             try:

--- a/sgdml/predict.py
+++ b/sgdml/predict.py
@@ -890,9 +890,9 @@ class GDMLPredict(object):
 
     def _save_cached_bmark_result(self, n_bulk, num_workers, chunk_size, bulk_mp, gps):
 
-        pkg_dir = os.path.dirname(os.path.abspath(__file__))
+        curr_dir = os.getcwd()
         bmark_file = '_bmark_cache.npz'
-        bmark_path = os.path.join(pkg_dir, bmark_file)
+        bmark_path = os.path.join(curr_dir, bmark_file)
 
         bkey = '{}-{}-{}-{}'.format(
             self.n_atoms, self.n_train, n_bulk, self.max_processes
@@ -922,9 +922,9 @@ class GDMLPredict(object):
 
     def _load_cached_bmark_result(self, n_bulk):
 
-        pkg_dir = os.path.dirname(os.path.abspath(__file__))
+        curr_dir = os.getcwd()
         bmark_file = '_bmark_cache.npz'
-        bmark_path = os.path.join(pkg_dir, bmark_file)
+        bmark_path = os.path.join(curr_dir, bmark_file)
 
         bkey = '{}-{}-{}-{}'.format(
             self.n_atoms, self.n_train, n_bulk, self.max_processes


### PR DESCRIPTION
**_bmark_cache.npz** file stores at program path will result several problem: 
1. if user install sgdml with system python (/usr/bin/python3), then the path `/usr/lib/python3.*/site-packages/sgdml` is not writable, which will results problem.
2. if users install sgdml in a cluster/workstation, and execute multiple tasks simultaneously, then **_bmark_cache.npz** will be overwrite multiple times. It will result verify fail or output error when one task read the wrong **_bmark_cache.npz** which is written by other task. This problem will also happened in cluster, when sgdml is installed in cluster software path, and calculation node uses this software path.

In my fix, I modify the **_bmark_cache.npz** path into current task execution path, it would solve this bug.  

I only test it in my task, I'm not sure whether this modification will introduce other bug or not.  

Because this modification related with file path, I also checked the python code `os.chdir` (which may conflict with my modification) , and not found the usage, so I think it may not introduce bug.  
