### PR TITLE
Fixed np.int bug on numpy>1.20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Setuptools distribution folder.
 /dist/
+/build/
 
 # Python egg metadata, regenerated from source files by setuptools.
 /*.egg-info

--- a/sgdml/utils/desc.py
+++ b/sgdml/utils/desc.py
@@ -264,7 +264,7 @@ class Desc(object):
         self.tril_indices = np.tril_indices(n_atoms, k=-1)
 
         # Precompute indices for nonzero entries in desriptor derivatives.
-        self.d_desc_mask = np.zeros((n_atoms, n_atoms - 1), dtype=np.int)
+        self.d_desc_mask = np.zeros((n_atoms, n_atoms - 1), dtype=int)
         for a in range(n_atoms):  # for each partial derivative
             rows, cols = self.tril_indices
             self.d_desc_mask[a, :] = np.concatenate(


### PR DESCRIPTION
tldr: np.int is deprecated since numpy > 1.20
(Also added /build/ to gitignore for convenience when testing)

Full error when using recent numpy version:
```
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```
